### PR TITLE
f2fs: disable fsck check

### DIFF
--- a/Volume.cpp
+++ b/Volume.cpp
@@ -531,6 +531,16 @@ int Volume::mountVol() {
                 }
 
             } else if (strcmp(fstype, "f2fs") == 0) {
+                /*
+                 * fsck.f2fs does not fix any inconsistencies "yet".
+                 *
+                 * Disable fsck routine as this is just wasting time
+                 * consumed to mount f2fs volumes.
+                 *
+                 * The kernel can determine if a f2fs volume is too damaged
+                 * that it shouldn't get mounted.
+                 */
+                #if 0
                 if (F2FS::check(devicePath)) {
                     errno = EIO;
                     /* Badness - abort the mount */
@@ -539,6 +549,7 @@ int Volume::mountVol() {
                     free(fstype);
                     return -1;
                 }
+                #endif
 
                 if (F2FS::doMount(devicePath, getMountpoint(), false, false, false, true)) {
                     SLOGE("%s failed to mount via F2FS (%s)\n", devicePath, strerror(errno));


### PR DESCRIPTION
fsck.f2fs does not fix any inconsistencies "yet".

Disable fsck routine as this is just wasting time consumed to mount f2fs volumes.

The kernel can determine if a f2fs volume is too damaged that it shouldn't get mounted.

We should wait for f2fs-tools version higher than v1.3.0.
(fsck.f2fs for fixing inconsistencies is a work-in-progress)

References:
https://github.com/torvalds/linux/blob/master/Documentation/filesystems/f2fs.txt#L261
https://git.kernel.org/cgit/linux/kernel/git/jaegeuk/f2fs-tools.git

Change-Id: I7e0a4662ac70860fe139bb9331b7aee1ad76220f
Signed-off-by: Park Ju Hyung qkrwngud825@gmail.com
